### PR TITLE
disable coloring when NO_COLOR env var is set

### DIFF
--- a/colo.js
+++ b/colo.js
@@ -74,7 +74,7 @@
       if (color) {
         if (isBrowser) {
           styles += color[2] + "; ";
-        } else {
+        } else if (!isEnvNoColor()) {
           result = '\u001b[' + color[0] + 'm' + result + '\u001b[' + color[1] + 'm';
         }
       }
@@ -84,6 +84,14 @@
     } else {
       return result;
     }
+  };
+
+  /**
+   * Checks if the NO_COLOR env var is set.
+   * @return {boolean}
+   */
+  var isEnvNoColor = function() {
+    return typeof process === "object" && process.env && !!process.env.NO_COLOR;
   };
 
   var styles = (function () {

--- a/test/test.js
+++ b/test/test.js
@@ -33,4 +33,21 @@ describe('colo', function(){
       assert.equal(colo.cyan(undefined), "\u001b[36mundefined\u001b[39m");
     });
   });
+
+  context("when NO_COLOR env var is set", function(){
+    before(function(){
+      process.env.NO_COLOR = "true";
+    });
+
+    after(function(){
+      process.env.NO_COLOR = undefined;
+    });
+
+    it("should not decorate the input", function(){
+      assert.equal(colo.bold("foo"), "foo");
+      assert.equal(colo.italic("foo"), "foo");
+      assert.equal(colo.red("foo"), "foo");
+      assert.equal(colo.cyan("foo"), "foo");
+    });
+  });
 });


### PR DESCRIPTION
- A person @jcs suggests the standard way of disabling color. See http://no-color.org/ https://twitter.com/matsuu/status/962252252508340224
- If colo supports this disabling switch, the dependent tools (like eater, eatest, agreed, saku etc) automatically conform the above standard and probably that makes everyone happy!